### PR TITLE
Enable support for Embedded Metric Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Run `make` to build `./bin/cloudwatch.so`. Then use with Fluent Bit:
 * `log_stream_name`: The name of the CloudWatch Log Stream that you want log records sent to.
 * `log_stream_prefix`: Prefix for the Log Stream name. The tag is appended to the prefix to construct the full log stream name. Not compatible with the `log_stream_name` option.  
 * `log_key`: By default, the whole log record will be sent to CloudWatch. If you specify a key name with this option, then only the value of that key will be sent to CloudWatch. For example, if you are using the Fluentd Docker log driver, you can specify `log_key log` and only the log message will be sent to CloudWatch.
+* `log_format`: An optional parameter that can be used to tell CloudWatch the format of the data. A value of `json/emf` enables CloudWatch to extract custom metrics embedded in a JSON payload. See the [Embedded Metric Format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html).
 * `role_arn`: ARN of an IAM role to assume (for cross account access).
 * `auto_create_group`: Automatically create the log group. Valid values are "true" or "false" (case insensitive). Defaults to false.
 * `endpoint`: Specify a custom endpoint for the CloudWatch Logs API.

--- a/cloudwatch/handlers.go
+++ b/cloudwatch/handlers.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cloudwatch
+
+import "github.com/aws/aws-sdk-go/aws/request"
+
+const logFormatHeader = "x-amzn-logs-format"
+
+// LogFormatHandler returns an http request handler that sets an HTTP header used to 
+// indicate the format of the logs being sent
+func LogFormatHandler(format string) request.NamedHandler {
+	return request.NamedHandler{
+		Name: "LogFormatHandler",
+		Fn: func(req *request.Request) {
+			req.HTTPRequest.Header.Set("x-amzn-logs-format", format)
+		},
+	}
+}

--- a/cloudwatch/handlers_test.go
+++ b/cloudwatch/handlers_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cloudwatch
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogFormatHandler(t *testing.T) {
+	httpReq, _ := http.NewRequest("POST", "", nil)
+	r := &request.Request{
+		HTTPRequest: httpReq,
+		Body:        nil,
+	}
+	r.SetBufferBody([]byte{})
+
+	handler := LogFormatHandler("json/emf")
+	handler.Fn(r)
+
+	header := r.HTTPRequest.Header.Get("x-amzn-logs-format")
+	assert.Equal(t, "json/emf", header)
+}

--- a/fluent-bit-cloudwatch.go
+++ b/fluent-bit-cloudwatch.go
@@ -85,6 +85,8 @@ func getConfiguration(ctx unsafe.Pointer, pluginID int) cloudwatch.OutputPluginC
 	logrus.Infof("[cloudwatch %d] plugin parameter endpoint = '%s'\n", pluginID, config.CWEndpoint)
 	config.CredsEndpoint = output.FLBPluginConfigKey(ctx, "credentials_endpoint")
 	logrus.Infof("[cloudwatch %d] plugin parameter credentials_endpoint = %s\n", pluginID, config.CredsEndpoint)
+	config.LogFormat = output.FLBPluginConfigKey(ctx, "log_format")
+	logrus.Infof("[cloudwatch %d] plugin parameter log_format = '%s'\n", pluginID, config.LogFormat)
 
 	return config
 }


### PR DESCRIPTION
*Issue #, if available:* #27 

*Description of changes:*

Enables custom log formats. This will enable Embedded Metrics if you specify a value of `json/emf` for the log format.

See https://github.com/aws/aws-for-fluent-bit/pull/21 for e2e tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
