### PR TITLE
Remove unused backoff field in OutputPlugin

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -86,7 +86,6 @@ type OutputPlugin struct {
 	logKey                        string
 	client                        LogsClient
 	streams                       map[string]*logStream
-	backoff                       *plugins.Backoff
 	timer                         *plugins.Timeout
 	nextLogStreamCleanUpCheckTime time.Time
 	PluginInstanceID              int


### PR DESCRIPTION
Meant to fix this issue, but it turns out that I never implemented backoff in this plugin: https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit/issues/23

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
