### PR TITLE
Log group name key

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Run `make` to build `./bin/cloudwatch.so`. Then use with Fluent Bit:
 
 * `region`: The AWS region.
 * `log_group_name`: The name of the CloudWatch Log Group that you want log records sent to.
+* `log_group_name_key`: An optional key for a dynamic Log Group name.
 * `log_stream_name`: The name of the CloudWatch Log Stream that you want log records sent to.
 * `log_stream_prefix`: Prefix for the Log Stream name. The tag is appended to the prefix to construct the full log stream name. Not compatible with the `log_stream_name` option.  
 * `log_key`: By default, the whole log record will be sent to CloudWatch. If you specify a key name with this option, then only the value of that key will be sent to CloudWatch. For example, if you are using the Fluentd Docker log driver, you can specify `log_key log` and only the log message will be sent to CloudWatch.

--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -509,9 +509,10 @@ func encodeLogKey(log *interface{}) ([]byte, error) {
 func (output *OutputPlugin) Flush(tag string) error {
 	output.cleanUpExpiredLogStreams() // will periodically clean up, otherwise is no-op
 
-	stream, err := output.getLogStream(tag, "")
-	if err != nil {
-		return err
+	name := output.getStreamName(tag)
+	stream, ok := output.streams[name]
+	if !ok {
+		return fmt.Errorf("Failed to find stream with tag: %s", tag)
 	}
 	return output.putLogEvents(stream)
 }

--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -81,6 +81,7 @@ func (stream *logStream) updateExpiration() {
 // OutputPlugin is the CloudWatch Logs Fluent Bit output plugin
 type OutputPlugin struct {
 	logGroupName                  string
+	logGroupNameKey               string
 	logStreamPrefix               string
 	logStreamName                 string
 	logKey                        string
@@ -89,13 +90,14 @@ type OutputPlugin struct {
 	timer                         *plugins.Timeout
 	nextLogStreamCleanUpCheckTime time.Time
 	PluginInstanceID              int
-	logGroupCreated               bool
+	autoCreateGroup               bool
 }
 
 // OutputPluginConfig is the input information used by NewOutputPlugin to create a new OutputPlugin
 type OutputPluginConfig struct {
 	Region           string
 	LogGroupName     string
+	LogGroupNameKey  string
 	LogStreamPrefix  string
 	LogStreamName    string
 	LogKey           string
@@ -113,8 +115,8 @@ func (config OutputPluginConfig) Validate() error {
 	if config.Region == "" {
 		return fmt.Errorf(errorStr, "region")
 	}
-	if config.LogGroupName == "" {
-		return fmt.Errorf(errorStr, "log_group_name")
+	if config.LogGroupName == "" && config.LogGroupNameKey == "" {
+		return fmt.Errorf("log_group_name or log_group_name_key is required")
 	}
 	if config.LogStreamName == "" && config.LogStreamPrefix == "" {
 		return fmt.Errorf("log_stream_name or log_stream_prefix is required")
@@ -153,7 +155,7 @@ func NewOutputPlugin(config OutputPluginConfig) (*OutputPlugin, error) {
 		streams:                       make(map[string]*logStream),
 		nextLogStreamCleanUpCheckTime: time.Now().Add(logStreamInactivityCheckInterval),
 		PluginInstanceID:              config.PluginInstanceID,
-		logGroupCreated:               !config.AutoCreateGroup,
+		autoCreateGroup:               config.AutoCreateGroup,
 	}, nil
 }
 
@@ -197,15 +199,6 @@ func newCloudWatchLogsClient(roleARN string, sess *session.Session, endpoint str
 // the return value is one of: FLB_OK, FLB_RETRY
 // API Errors lead to an FLB_RETRY, and all other errors are logged, the record is discarded and FLB_OK is returned
 func (output *OutputPlugin) AddEvent(tag string, record map[interface{}]interface{}, timestamp time.Time) int {
-	if !output.logGroupCreated {
-		err := output.createLogGroup()
-		if err != nil {
-			logrus.Error(err)
-			return fluentbit.FLB_ERROR
-		}
-		output.logGroupCreated = true
-	}
-
 	data, err := output.processRecord(record)
 	if err != nil {
 		logrus.Errorf("[cloudwatch %d] %v\n", output.PluginInstanceID, err)
@@ -220,7 +213,14 @@ func (output *OutputPlugin) AddEvent(tag string, record map[interface{}]interfac
 		return fluentbit.FLB_OK
 	}
 
-	stream, err := output.getLogStream(tag)
+	groupName, err := output.getGroupName(record)
+	if err != nil {
+		logrus.Errorf("[cloudwatch %d] %v\n", output.PluginInstanceID, err)
+		// plugin is misconfigured
+		return fluentbit.FLB_ERROR
+	}
+
+	stream, err := output.getLogStream(tag, groupName)
 	if err != nil {
 		logrus.Errorf("[cloudwatch %d] %v\n", output.PluginInstanceID, err)
 		// an error means that the log stream was not created; this is retryable
@@ -271,25 +271,36 @@ func (output *OutputPlugin) cleanUpExpiredLogStreams() {
 	}
 }
 
-func (output *OutputPlugin) getLogStream(tag string) (*logStream, error) {
+func (output *OutputPlugin) getLogStream(tag, groupName string) (*logStream, error) {
 	// find log stream by tag
 	name := output.getStreamName(tag)
 	stream, ok := output.streams[name]
-	if !ok {
-		// stream doesn't exist, create it
-		stream, err := output.createStream(tag)
+	if ok {
+		return stream, nil
+	}
+	// extra check, empty groupName indicates flush phase, but still land here meaning unable to find stream
+	if groupName == "" {
+		return nil, fmt.Errorf("error: does not compute: Log Stream %s could not be created, but also could not be found in the log group", name)
+	}
+	if output.autoCreateGroup {
+		err := output.createLogGroup(groupName)
 		if err != nil {
-			if awsErr, ok := err.(awserr.Error); ok {
-				if awsErr.Code() == cloudwatchlogs.ErrCodeResourceAlreadyExistsException {
-					// existing stream
-					return output.existingLogStream(tag)
-				}
+			if awsErr, ok := err.(awserr.Error); !ok || awsErr.Code() != cloudwatchlogs.ErrCodeResourceAlreadyExistsException {
+				return nil, err
 			}
 		}
-		return stream, err
 	}
-
-	return stream, nil
+	// stream doesn't exist, create it
+	stream, err := output.createStream(tag, groupName)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == cloudwatchlogs.ErrCodeResourceAlreadyExistsException {
+				// existing stream
+				return output.existingLogStream(tag)
+			}
+		}
+	}
+	return stream, err
 }
 
 func (output *OutputPlugin) existingLogStream(tag string) (*logStream, error) {
@@ -343,6 +354,24 @@ func (output *OutputPlugin) describeLogStreams(name string, nextToken *string) (
 	return resp, err
 }
 
+func (output *OutputPlugin) getGroupName(record map[interface{}]interface{}) (string, error) {
+	if output.logGroupName != "" {
+		return output.logGroupName, nil
+	}
+	if output.logGroupNameKey != "" {
+		if _, ok := record[output.logGroupNameKey]; !ok {
+			return "", fmt.Errorf("Failed to find key %s specified by log_group_name_key option in log record: %v", output.logGroupNameKey, record)
+		}
+		name, ok := record[output.logGroupNameKey].(string)
+		if !ok {
+			return "", fmt.Errorf("Failed to parse key %s as a string in log record: %v", output.logGroupNameKey, record)
+		}
+		return name, nil
+
+	}
+	return "", fmt.Errorf("Failed to find valid group name settings")
+}
+
 func (output *OutputPlugin) getStreamName(tag string) string {
 	name := output.logStreamName
 	if output.logStreamPrefix != "" {
@@ -352,11 +381,11 @@ func (output *OutputPlugin) getStreamName(tag string) string {
 	return name
 }
 
-func (output *OutputPlugin) createStream(tag string) (*logStream, error) {
+func (output *OutputPlugin) createStream(tag, groupName string) (*logStream, error) {
 	output.timer.Check()
 	name := output.getStreamName(tag)
 	_, err := output.client.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
-		LogGroupName:  aws.String(output.logGroupName),
+		LogGroupName:  aws.String(groupName),
 		LogStreamName: aws.String(name),
 	})
 
@@ -379,9 +408,9 @@ func (output *OutputPlugin) createStream(tag string) (*logStream, error) {
 	return stream, nil
 }
 
-func (output *OutputPlugin) createLogGroup() error {
+func (output *OutputPlugin) createLogGroup(groupName string) error {
 	_, err := output.client.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
-		LogGroupName: aws.String(output.logGroupName),
+		LogGroupName: aws.String(groupName),
 	})
 
 	if err != nil {
@@ -472,17 +501,9 @@ func encodeLogKey(log *interface{}) ([]byte, error) {
 
 // Flush sends the current buffer of records (for the stream that corresponds with the given tag)
 func (output *OutputPlugin) Flush(tag string) error {
-	if !output.logGroupCreated {
-		err := output.createLogGroup()
-		if err != nil {
-			return err
-		}
-		output.logGroupCreated = true
-	}
-
 	output.cleanUpExpiredLogStreams() // will periodically clean up, otherwise is no-op
 
-	stream, err := output.getLogStream(tag)
+	stream, err := output.getLogStream(tag, "")
 	if err != nil {
 		return err
 	}

--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -279,7 +279,7 @@ func (output *OutputPlugin) getLogStream(tag, groupName string) (*logStream, err
 	if ok {
 		return stream, nil
 	}
-	// extra check, empty groupName indicates flush phase, but still land here meaning unable to find stream
+
 	if groupName == "" {
 		return nil, fmt.Errorf("groupName cannot be empty")
 	}

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -45,6 +45,10 @@ func TestAddEvent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
+	mockCloudWatch.EXPECT().CreateLogGroup(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogGroupInput) {
+		assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+	}).Return(&cloudwatchlogs.CreateLogGroupOutput{}, nil)
+
 	mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 		assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 		assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
@@ -57,7 +61,7 @@ func TestAddEvent(t *testing.T) {
 		backoff:         plugins.NewBackoff(),
 		timer:           setupTimeout(),
 		streams:         make(map[string]*logStream),
-		logGroupCreated: true,
+		autoCreateGroup: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -74,7 +78,6 @@ func TestAddEventCreateLogGroup(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
-		mockCloudWatch.EXPECT().CreateLogGroup(gomock.Any()).Return(&cloudwatchlogs.CreateLogGroupOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
@@ -88,7 +91,7 @@ func TestAddEventCreateLogGroup(t *testing.T) {
 		backoff:         plugins.NewBackoff(),
 		timer:           setupTimeout(),
 		streams:         make(map[string]*logStream),
-		logGroupCreated: false,
+		autoCreateGroup: false,
 	}
 
 	record := map[interface{}]interface{}{
@@ -106,6 +109,9 @@ func TestAddEventExistingStream(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().CreateLogGroup(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogGroupInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.CreateLogGroupOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
@@ -142,7 +148,7 @@ func TestAddEventExistingStream(t *testing.T) {
 		backoff:         plugins.NewBackoff(),
 		timer:           setupTimeout(),
 		streams:         make(map[string]*logStream),
-		logGroupCreated: true,
+		autoCreateGroup: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -159,6 +165,9 @@ func TestAddEventExistingStreamNotFound(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().CreateLogGroup(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogGroupInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.CreateLogGroupOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
@@ -194,7 +203,7 @@ func TestAddEventExistingStreamNotFound(t *testing.T) {
 		backoff:         plugins.NewBackoff(),
 		timer:           setupTimeout(),
 		streams:         make(map[string]*logStream),
-		logGroupCreated: true,
+		autoCreateGroup: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -218,7 +227,7 @@ func TestAddEventEmptyRecord(t *testing.T) {
 		timer:           setupTimeout(),
 		streams:         make(map[string]*logStream),
 		logKey:          "somekey",
-		logGroupCreated: true,
+		autoCreateGroup: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -235,6 +244,9 @@ func TestAddEventAndFlush(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().CreateLogGroup(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogGroupInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.CreateLogGroupOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
@@ -254,7 +266,7 @@ func TestAddEventAndFlush(t *testing.T) {
 		backoff:         plugins.NewBackoff(),
 		timer:           setupTimeout(),
 		streams:         make(map[string]*logStream),
-		logGroupCreated: true,
+		autoCreateGroup: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -271,6 +283,9 @@ func TestAddEventAndFlushDataAlreadyAcceptedException(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().CreateLogGroup(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogGroupInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.CreateLogGroupOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
@@ -288,7 +303,7 @@ func TestAddEventAndFlushDataAlreadyAcceptedException(t *testing.T) {
 		backoff:         plugins.NewBackoff(),
 		timer:           setupTimeout(),
 		streams:         make(map[string]*logStream),
-		logGroupCreated: true,
+		autoCreateGroup: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -306,6 +321,9 @@ func TestAddEventAndFlushDataInvalidSequenceTokenException(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().CreateLogGroup(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogGroupInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.CreateLogGroupOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
@@ -330,7 +348,7 @@ func TestAddEventAndFlushDataInvalidSequenceTokenException(t *testing.T) {
 		backoff:         plugins.NewBackoff(),
 		timer:           setupTimeout(),
 		streams:         make(map[string]*logStream),
-		logGroupCreated: true,
+		autoCreateGroup: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -435,6 +453,9 @@ func setupLimitTestOutput(t *testing.T, times int) OutputPlugin {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().CreateLogGroup(gomock.Any()).AnyTimes().Do(func(input *cloudwatchlogs.CreateLogGroupInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.CreateLogGroupOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).AnyTimes().Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
@@ -449,7 +470,7 @@ func setupLimitTestOutput(t *testing.T, times int) OutputPlugin {
 		backoff:         plugins.NewBackoff(),
 		timer:           setupTimeout(),
 		streams:         make(map[string]*logStream),
-		logGroupCreated: true,
+		autoCreateGroup: true,
 	}
 }
 

--- a/fluent-bit-cloudwatch.go
+++ b/fluent-bit-cloudwatch.go
@@ -69,6 +69,8 @@ func getConfiguration(ctx unsafe.Pointer, pluginID int) cloudwatch.OutputPluginC
 	config.PluginInstanceID = pluginID
 	config.LogGroupName = output.FLBPluginConfigKey(ctx, "log_group_name")
 	logrus.Infof("[cloudwatch %d] plugin parameter log_group = '%s'\n", pluginID, config.LogGroupName)
+	config.LogGroupNameKey = output.FLBPluginConfigKey(ctx, "log_group_name_key")
+	logrus.Infof("[cloudwatch %d] plugin parameter log_group_name_key = '%s'\n", pluginID, config.LogGroupNameKey)
 	config.LogStreamPrefix = output.FLBPluginConfigKey(ctx, "log_stream_prefix")
 	logrus.Infof("[cloudwatch %d] plugin parameter log_stream_prefix = '%s'\n", pluginID, config.LogStreamPrefix)
 	config.LogStreamName = output.FLBPluginConfigKey(ctx, "log_stream_name")


### PR DESCRIPTION
*Issue #46*

Add support for dynamic log group names via a `log_group_name_key` option.
This picks up the work from @owlwalks and replaces PR #24.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
