### PR TITLE
Add empty check before calling PutLogEvents

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -463,6 +463,11 @@ func (output *OutputPlugin) Flush(tag string) error {
 }
 
 func (output *OutputPlugin) putLogEvents(stream *logStream) error {
+	// return in case of empty logEvents
+	if len(stream.logEvents) == 0 {
+		return nil
+	}
+
 	output.timer.Check()
 	stream.updateExpiration()
 

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -260,6 +260,25 @@ func TestAddEventAndFlush(t *testing.T) {
 	output.Flush(testTag)
 }
 
+func TestPutLogEvents(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
+
+	output := OutputPlugin{
+		logGroupName:    testLogGroup,
+		logStreamPrefix: testLogStreamPrefix,
+		client:          mockCloudWatch,
+		timer:           setupTimeout(),
+		streams:         make(map[string]*logStream),
+		logKey:          "somekey",
+		logGroupCreated: true,
+	}
+
+	stream := &logStream{}
+	err := output.putLogEvents(stream)
+	assert.Nil(t, err)
+}
+
 func TestAddEventAndFlushDataAlreadyAcceptedException(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)


### PR DESCRIPTION
*Description of changes:*
Add an empty check before calling PutLogEvents. If no logEvents is attached, do not make the PutLogEvents API call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
