### PR TITLE
Add back auto_create_group parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ use the form `$(variable['subkey'])`. Special values: `$(tag)` references the fu
 * `log_key`: By default, the whole log record will be sent to CloudWatch. If you specify a key name with this option, then only the value of that key will be sent to CloudWatch. For example, if you are using the Fluentd Docker log driver, you can specify `log_key log` and only the log message will be sent to CloudWatch.
 * `log_format`: An optional parameter that can be used to tell CloudWatch the format of the data. A value of `json/emf` enables CloudWatch to extract custom metrics embedded in a JSON payload. See the [Embedded Metric Format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html).
 * `role_arn`: ARN of an IAM role to assume (for cross account access).
+* `auto_create_group`: Automatically create log groups (and add tags). Valid values are "true" or "false" (case insensitive). Defaults to true.
 * `new_log_group_tags`: Comma/equal delimited string of tags to include with _auto created_ log groups. Example: `"tag=val,cooltag2=my other value"`
 * `log_retention_days`: If set to a number greater than zero, and newly create log group's retention policy is set to this many days.
 * `endpoint`: Specify a custom endpoint for the CloudWatch Logs API.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ use the form `$(variable['subkey'])`. Special values: `$(tag)` references the fu
 * `log_key`: By default, the whole log record will be sent to CloudWatch. If you specify a key name with this option, then only the value of that key will be sent to CloudWatch. For example, if you are using the Fluentd Docker log driver, you can specify `log_key log` and only the log message will be sent to CloudWatch.
 * `log_format`: An optional parameter that can be used to tell CloudWatch the format of the data. A value of `json/emf` enables CloudWatch to extract custom metrics embedded in a JSON payload. See the [Embedded Metric Format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html).
 * `role_arn`: ARN of an IAM role to assume (for cross account access).
-* `auto_create_group`: Automatically create log groups (and add tags). Valid values are "true" or "false" (case insensitive). Defaults to true.
+* `auto_create_group`: Automatically create log groups (and add tags). Valid values are "true" or "false" (case insensitive). Defaults to false. If you use dynamic variables in your log group name, you may need this to be `true`.
 * `new_log_group_tags`: Comma/equal delimited string of tags to include with _auto created_ log groups. Example: `"tag=val,cooltag2=my other value"`
 * `log_retention_days`: If set to a number greater than zero, and newly create log group's retention policy is set to this many days.
 * `endpoint`: Specify a custom endpoint for the CloudWatch Logs API.

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -121,6 +121,7 @@ func TestAddEventCreateLogGroup(t *testing.T) {
 		streams:           make(map[string]*logStream),
 		groups:            make(map[string]struct{}),
 		logGroupRetention: 14,
+		autoCreateGroup:   true,
 	}
 
 	record := map[interface{}]interface{}{

--- a/fluent-bit-cloudwatch.go
+++ b/fluent-bit-cloudwatch.go
@@ -86,7 +86,7 @@ func getConfiguration(ctx unsafe.Pointer, pluginID int) cloudwatch.OutputPluginC
 	config.RoleARN = output.FLBPluginConfigKey(ctx, "role_arn")
 	logrus.Infof("[cloudwatch %d] plugin parameter role_arn = '%s'", pluginID, config.RoleARN)
 
-	config.AutoCreateGroup = getBoolParam(ctx, "auto_create_group", true)
+	config.AutoCreateGroup = getBoolParam(ctx, "auto_create_group", false)
 	logrus.Infof("[cloudwatch %d] plugin parameter auto_create_group = '%v'", pluginID, config.AutoCreateGroup)
 
 	config.NewLogGroupTags = output.FLBPluginConfigKey(ctx, "new_log_group_tags")

--- a/fluent-bit-cloudwatch.go
+++ b/fluent-bit-cloudwatch.go
@@ -67,28 +67,43 @@ func FLBPluginRegister(ctx unsafe.Pointer) int {
 func getConfiguration(ctx unsafe.Pointer, pluginID int) cloudwatch.OutputPluginConfig {
 	config := cloudwatch.OutputPluginConfig{}
 	config.PluginInstanceID = pluginID
+
 	config.LogGroupName = output.FLBPluginConfigKey(ctx, "log_group_name")
 	logrus.Infof("[cloudwatch %d] plugin parameter log_group = '%s'", pluginID, config.LogGroupName)
+
 	config.LogStreamPrefix = output.FLBPluginConfigKey(ctx, "log_stream_prefix")
 	logrus.Infof("[cloudwatch %d] plugin parameter log_stream_prefix = '%s'", pluginID, config.LogStreamPrefix)
+
 	config.LogStreamName = output.FLBPluginConfigKey(ctx, "log_stream_name")
 	logrus.Infof("[cloudwatch %d] plugin parameter log_stream_name = '%s'", pluginID, config.LogStreamName)
+
 	config.Region = output.FLBPluginConfigKey(ctx, "region")
 	logrus.Infof("[cloudwatch %d] plugin parameter region = '%s'", pluginID, config.Region)
+
 	config.LogKey = output.FLBPluginConfigKey(ctx, "log_key")
 	logrus.Infof("[cloudwatch %d] plugin parameter log_key = '%s'", pluginID, config.LogKey)
+
 	config.RoleARN = output.FLBPluginConfigKey(ctx, "role_arn")
 	logrus.Infof("[cloudwatch %d] plugin parameter role_arn = '%s'", pluginID, config.RoleARN)
+
+	config.AutoCreateGroup = getBoolParam(ctx, "auto_create_group", true)
+	logrus.Infof("[cloudwatch %d] plugin parameter auto_create_group = '%v'", pluginID, config.AutoCreateGroup)
+
 	config.NewLogGroupTags = output.FLBPluginConfigKey(ctx, "new_log_group_tags")
 	logrus.Infof("[cloudwatch %d] plugin parameter new_log_group_tags = '%s'", pluginID, config.NewLogGroupTags)
+
 	config.LogRetentionDays, _ = strconv.ParseInt(output.FLBPluginConfigKey(ctx, "log_retention_days"), 10, 64)
 	logrus.Infof("[cloudwatch %d] plugin parameter log_retention_days = '%d'", pluginID, config.LogRetentionDays)
+
 	config.CWEndpoint = output.FLBPluginConfigKey(ctx, "endpoint")
 	logrus.Infof("[cloudwatch %d] plugin parameter endpoint = '%s'", pluginID, config.CWEndpoint)
+
 	config.STSEndpoint = output.FLBPluginConfigKey(ctx, "sts_endpoint")
 	logrus.Infof("[cloudwatch %d] plugin parameter sts_endpoint = '%s'", pluginID, config.STSEndpoint)
+
 	config.CredsEndpoint = output.FLBPluginConfigKey(ctx, "credentials_endpoint")
 	logrus.Infof("[cloudwatch %d] plugin parameter credentials_endpoint = %s", pluginID, config.CredsEndpoint)
+
 	config.LogFormat = output.FLBPluginConfigKey(ctx, "log_format")
 	logrus.Infof("[cloudwatch %d] plugin parameter log_format = '%s'", pluginID, config.LogFormat)
 


### PR DESCRIPTION
*Issue #, if available:* fixes #96 

*Description of changes:*

Adds the missing/ignored `auto_create_group` input parameter back to the codebase. If it is `false` the `createLogGroup` method always returns `nil` without doing anything. This effectively skips creating any needed groups.

**EDIT: I've tested this in my environment and it's working as expected with this new parameter set to both false and true.**

Set to `false`:
```
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter log_group = '/ecs/twitch-fluentbit-syslog/$(tag)/$(host)'"
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter log_stream_prefix = ''"
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter log_stream_name = '$(tag[0]).$(ident)'"
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter region = 'us-west-2'"
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter log_key = ''"
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter role_arn = ''"
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter auto_create_group = 'false'"
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter new_log_group_tags = ''"
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter log_retention_days = '60'"
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter endpoint = ''"
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter sts_endpoint = ''"
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter credentials_endpoint = "
time="2020-09-26T01:01:58Z" level=info msg="[cloudwatch 0] plugin parameter log_format = ''"
time="2020-09-26T01:01:58Z" level=debug msg="[cloudwatch 0] Initializing NewOutputPlugin"
[2020/09/26 01:01:58] [ info] [engine] started (pid=1)
[2020/09/26 01:01:58] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/09/26 01:01:58] [debug] [storage] [cio stream] new stream registered: syslog.0
[2020/09/26 01:01:58] [debug] [storage] [cio stream] new stream registered: syslog.1
[2020/09/26 01:01:58] [ info] [storage] version=1.0.4, initializing...
[2020/09/26 01:01:58] [ info] [storage] in-memory
[2020/09/26 01:01:58] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/09/26 01:01:58] [debug] [router] match rule syslog.0:cloudwatch.0
[2020/09/26 01:01:58] [debug] [router] match rule syslog.1:cloudwatch.0
[2020/09/26 01:01:58] [ info] [sp] stream processor started
[2020/09/26 01:03:47] [debug] [input:syslog:syslog.1] new Unix connection arrived FD=21
[2020/09/26 01:03:47] [debug] [input:syslog:syslog.1] new Unix connection arrived FD=22
[2020/09/26 01:03:48] [debug] [input:syslog:syslog.1] new Unix connection arrived FD=23
[2020/09/26 01:03:48] [debug] [task] created task=0x7fe6f427a0a0 id=0 OK
time="2020-09-26T01:03:48Z" level=debug msg="[cloudwatch 0] Found logs with tag: syslog.1"
time="2020-09-26T01:03:48Z" level=debug msg="[cloudwatch 0] Finding log group: /ecs/twitch-fluentbit-syslog/syslog.1/ib-server.name"
time="2020-09-26T01:03:48Z" level=debug msg="[cloudwatch 0] Initializing internal buffer for exising log stream syslog.named\n"
time="2020-09-26T01:03:48Z" level=debug msg="[cloudwatch 0] Finding log group: /ecs/twitch-fluentbit-syslog/syslog.1/ib-server.name2"
time="2020-09-26T01:03:48Z" level=debug msg="[cloudwatch 0] Initializing internal buffer for exising log stream syslog.dhcpd\n"
time="2020-09-26T01:03:48Z" level=debug msg="[cloudwatch 0] Initializing internal buffer for exising log stream syslog.httpd\n"
 time="2020-09-26T01:03:48Z" level=debug msg="[cloudwatch 0] Initializing internal buffer for exising log stream syslog.named\n"
time="2020-09-26T01:03:48Z" level=debug msg="[cloudwatch 0] Finding log group: /ecs/twitch-fluentbit-syslog/syslog.1/ib-server.name3"
```

Set to `true`:
```
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter log_group = '/ecs/twitch-fluentbit-syslog/$(tag)/$(host)'"
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter log_stream_prefix = ''"
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter log_stream_name = '$(tag[0]).$(ident)'"
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter region = 'us-west-2'"
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter log_key = ''"
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter role_arn = ''"
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter auto_create_group = 'true'"
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter new_log_group_tags = ''"
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter log_retention_days = '60'"
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter endpoint = ''"
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter sts_endpoint = ''"
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter credentials_endpoint = "
time="2020-09-26T02:00:45Z" level=info msg="[cloudwatch 0] plugin parameter log_format = ''"
time="2020-09-26T02:00:45Z" level=debug msg="[cloudwatch 0] Initializing NewOutputPlugin"
[2020/09/26 02:00:45] [ info] [engine] started (pid=1)
[2020/09/26 02:00:45] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/09/26 02:00:45] [debug] [storage] [cio stream] new stream registered: syslog.0
[2020/09/26 02:00:45] [debug] [storage] [cio stream] new stream registered: syslog.1
[2020/09/26 02:00:45] [ info] [storage] version=1.0.4, initializing...
[2020/09/26 02:00:45] [ info] [storage] in-memory
[2020/09/26 02:00:45] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/09/26 02:00:45] [debug] [router] match rule syslog.0:cloudwatch.0
[2020/09/26 02:00:45] [debug] [router] match rule syslog.1:cloudwatch.0
[2020/09/26 02:00:45] [ info] [sp] stream processor started
[2020/09/26 02:02:48] [debug] [input:syslog:syslog.1] new Unix connection arrived FD=21
[2020/09/26 02:02:49] [debug] [input:syslog:syslog.1] new Unix connection arrived FD=22
[2020/09/26 02:02:49] [debug] [task] created task=0x7fd62de7a0a0 id=0 OK
time="2020-09-26T02:02:49Z" level=debug msg="[cloudwatch 0] Found logs with tag: syslog.1"09-26T02:02:49Z" level=debug msg="[cloudwatch 0] Finding log group: /ecs/twitch-fluentbit-syslog/syslog.1/ib-server.name"
time="2020-09-26T02:02:49Z" level=info msg="[cloudwatch 0] Log group /ecs/twitch-fluentbit-syslog/syslog.1/ib-server.name already exists\n"
time="2020-09-26T02:02:50Z" level=debug msg="[cloudwatch 0] Initializing internal buffer for exising log stream syslog.dhcpd\n"
time="2020-09-26T02:02:50Z" level=debug msg="[cloudwatch 0] Initializing internal buffer for exising log stream syslog.httpd\n"
time="2020-09-26T02:02:50Z" level=debug msg="[cloudwatch 0] Initializing internal buffer for exising log stream syslog.named\n"
time="2020-09-26T02:02:50Z" level=debug msg="[cloudwatch 0] Finding log group: /ecs/twitch-fluentbit-syslog/syslog.1/ib-server.name2"
time="2020-09-26T02:02:50Z" level=info msg="[cloudwatch 0] Log group /ecs/twitch-fluentbit-syslog/syslog.1/ib-server.name2 already exists\n"
time="2020-09-26T02:02:50Z" level=debug msg="[cloudwatch 0] Initializing internal buffer for exising log stream syslog.named\n"
```

The `Already exists` message is only emitted after it attempts to create the log group.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
