### PR TITLE
Re-create log groups or log streams after they are deleted

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -645,6 +645,22 @@ func (output *OutputPlugin) putLogEvents(stream *logStream) error {
 				stream.nextSequenceToken = &parts[len(parts)-1]
 
 				return output.putLogEvents(stream)
+			} else if awsErr.Code() == cloudwatchlogs.ErrCodeResourceNotFoundException {
+				// a log group or a log stream should be re-created after it is deleted and then retry
+				logrus.Errorf("[cloudwatch %d] Encountered error %v; detailed information: %s\n", output.PluginInstanceID, awsErr, awsErr.Message())
+				if strings.Contains(awsErr.Message(), "group") {
+					if err := output.createLogGroup(&Event{group: stream.logGroupName}); err != nil {
+						logrus.Error(err)
+						return err
+					}
+				} else if strings.Contains(awsErr.Message(), "stream") {
+					if _, err := output.createStream(&Event{group: stream.logGroupName, stream: stream.logStreamName}); err != nil {
+						logrus.Error(err)
+						return err
+					}
+				}
+
+				return fmt.Errorf("[cloudwatch %d] A Log group/stream did not exist, re-created it. Will retry PutLogEvents on next flush", output.PluginInstanceID)
 			} else {
 				output.timer.Start()
 				return err


### PR DESCRIPTION
*Issue #95 

*Description of changes:*
Re-create the specific log group or log stream after it is deleted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
