### PR TITLE
Add validation to stop accepting both of LogStream and LogStreamPrefix together

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -171,6 +171,10 @@ func (config OutputPluginConfig) Validate() error {
 		return fmt.Errorf("log_stream_name or log_stream_prefix is required")
 	}
 
+	if config.LogStreamName != "" && config.LogStreamPrefix != "" {
+		return fmt.Errorf("either log_stream_name or log_stream_prefix can be configured. They cannot be provided together")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Rayhan Hossain <hossain.rayhan@outlook.com>

*Issue #, if available:* #173

*Description of changes:*
This PR will stop the output plugin to accept LogStreamName and LogStreamPrefix together. This is an invalid use case and the plugin should return an error. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
