### PR TITLE
Add auto_create_stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Run `make` to build `./bin/cloudwatch.so`. Then use with Fluent Bit:
 * `log_format`: An optional parameter that can be used to tell CloudWatch the format of the data. A value of `json/emf` enables CloudWatch to extract custom metrics embedded in a JSON payload. See the [Embedded Metric Format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html).
 * `role_arn`: ARN of an IAM role to assume (for cross account access).
 * `auto_create_group`: Automatically create log groups (and add tags). Valid values are "true" or "false" (case insensitive). Defaults to false. If you use dynamic variables in your log group name, you may need this to be `true`.
+* `auto_create_stream`: Automatically create log streams. Valid values are "true" or "false" (case insensitive). Defaults to true.
 * `new_log_group_tags`: Comma/equal delimited string of tags to include with _auto created_ log groups. Example: `"tag=val,cooltag2=my other value"`
 * `log_retention_days`: If set to a number greater than zero, and newly create log group's retention policy is set to this many days.
 * `endpoint`: Specify a custom endpoint for the CloudWatch Logs API.

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -691,6 +691,46 @@ func TestAddEventAndFlushDataInvalidSequenceTokenException(t *testing.T) {
 	output.Flush()
 }
 
+func TestAddEventAndFlushDataInvalidSequenceTokenNextNullException(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
+
+	gomock.InOrder(
+		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
+		}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil),
+		mockCloudWatch.EXPECT().PutLogEvents(gomock.Any()).Do(func(input *cloudwatchlogs.PutLogEventsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
+		}).Return(nil, awserr.New(cloudwatchlogs.ErrCodeInvalidSequenceTokenException, "The given sequenceToken is invalid; The next expected sequenceToken is: null", fmt.Errorf("API Error"))),
+		mockCloudWatch.EXPECT().PutLogEvents(gomock.Any()).Do(func(input *cloudwatchlogs.PutLogEventsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
+			assert.Nil(t, input.SequenceToken, "Expected sequence token to be nil")
+		}).Return(&cloudwatchlogs.PutLogEventsOutput{
+			NextSequenceToken: aws.String("token"),
+		}, nil),
+	)
+
+	output := OutputPlugin{
+		logGroupName:    testTemplate(testLogGroup),
+		logStreamPrefix: testLogStreamPrefix,
+		client:          mockCloudWatch,
+		timer:           setupTimeout(),
+		streams:         make(map[string]*logStream),
+		groups:          map[string]struct{}{testLogGroup: {}},
+	}
+
+	record := map[interface{}]interface{}{
+		"somekey": []byte("some value"),
+	}
+
+	retCode := output.AddEvent(&Event{TS: time.Now(), Tag: testTag, Record: record})
+	assert.Equal(t, retCode, fluentbit.FLB_OK, "Expected return code to FLB_OK")
+	output.Flush()
+}
+
 func TestAddEventAndDataResourceNotFoundExceptionWithNoLogGroup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -130,18 +130,24 @@ func TestAddEvent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
-	mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
-		assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
-		assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
-	}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil)
+	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
+		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil),
+	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -156,18 +162,24 @@ func TestTruncateLargeLogEvent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
-	mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
-		assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
-		assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
-	}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil)
+	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
+		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil),
+	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -189,18 +201,24 @@ func TestTruncateLargeLogEventWithSpecialCharacterOneTrailingFragments(t *testin
 	ctrl := gomock.NewController(t)
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
-	mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
-		assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
-		assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
-	}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil)
+	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
+		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil),
+	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	var b bytes.Buffer
@@ -234,19 +252,24 @@ func TestTruncateLargeLogEventWithSpecialCharacterOneTrailingFragments(t *testin
 func TestTruncateLargeLogEventWithSpecialCharacterTwoTrailingFragments(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
-
-	mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
-		assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
-		assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
-	}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil)
+	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
+		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil),
+	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	var b bytes.Buffer
@@ -280,19 +303,24 @@ func TestTruncateLargeLogEventWithSpecialCharacterTwoTrailingFragments(t *testin
 func TestTruncateLargeLogEventWithSpecialCharacterThreeTrailingFragments(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
-
-	mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
-		assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
-		assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
-	}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil)
+	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
+		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil),
+	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	var b bytes.Buffer
@@ -330,6 +358,9 @@ func TestAddEventCreateLogGroup(t *testing.T) {
 	gomock.InOrder(
 		mockCloudWatch.EXPECT().CreateLogGroup(gomock.Any()).Return(&cloudwatchlogs.CreateLogGroupOutput{}, nil),
 		mockCloudWatch.EXPECT().PutRetentionPolicy(gomock.Any()).Return(&cloudwatchlogs.PutRetentionPolicyOutput{}, nil),
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
@@ -345,6 +376,7 @@ func TestAddEventCreateLogGroup(t *testing.T) {
 		groups:            make(map[string]struct{}),
 		logGroupRetention: 14,
 		autoCreateGroup:   true,
+		autoCreateStream:  true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -362,10 +394,6 @@ func TestAddEventExistingStream(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
-		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
-			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
-			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
-		}).Return(nil, awserr.New(cloudwatchlogs.ErrCodeResourceAlreadyExistsException, "Log Stream already exists", fmt.Errorf("API Error"))),
 		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamNamePrefix), testLogStreamPrefix+testTag, "Expected log group name to match")
@@ -409,15 +437,64 @@ func TestAddEventExistingStream(t *testing.T) {
 
 }
 
+func TestAddEventDescribeStreamsException(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
+
+	mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+	}).Return(nil, awserr.New(cloudwatchlogs.ErrCodeResourceNotFoundException, "The specified log group does not exist.", fmt.Errorf("API Error")))
+
+	output := OutputPlugin{
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
+	}
+
+	record := map[interface{}]interface{}{
+		"somekey": []byte("some value"),
+	}
+
+	retCode := output.AddEvent(&Event{TS: time.Now(), Tag: testTag, Record: record})
+	assert.Equal(t, retCode, fluentbit.FLB_RETRY, "Expected return code to FLB_OK")
+}
+
+func TestAddEventAutoCreateDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
+
+	mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+		assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+	}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil)
+	mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
+	}).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil).Times(0)
+
+	output := OutputPlugin{
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: false,
+	}
+
+	record := map[interface{}]interface{}{
+		"somekey": []byte("some value"),
+	}
+
+	retCode := output.AddEvent(&Event{TS: time.Now(), Tag: testTag, Record: record})
+	assert.Equal(t, retCode, fluentbit.FLB_RETRY, "Expected return code to FLB_RETRY")
+}
+
 func TestAddEventExistingStreamNotFound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
-		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
-			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
-			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
-		}).Return(nil, awserr.New(cloudwatchlogs.ErrCodeResourceAlreadyExistsException, "Log Stream already exists", fmt.Errorf("API Error"))),
 		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamNamePrefix), testLogStreamPrefix+testTag, "Expected log group name to match")
@@ -440,15 +517,20 @@ func TestAddEventExistingStreamNotFound(t *testing.T) {
 				},
 			},
 		}, nil),
+		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log group name to match")
+		}).Return(nil, awserr.New(cloudwatchlogs.ErrCodeResourceAlreadyExistsException, "Log Stream already exists", fmt.Errorf("API Error"))),
 	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -488,6 +570,9 @@ func TestAddEventAndFlush(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
@@ -501,12 +586,13 @@ func TestAddEventAndFlush(t *testing.T) {
 	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -623,6 +709,9 @@ func TestAddEventAndFlushDataAlreadyAcceptedException(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
@@ -634,12 +723,13 @@ func TestAddEventAndFlushDataAlreadyAcceptedException(t *testing.T) {
 	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -656,6 +746,9 @@ func TestAddEventAndFlushDataInvalidSequenceTokenException(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
@@ -674,12 +767,13 @@ func TestAddEventAndFlushDataInvalidSequenceTokenException(t *testing.T) {
 	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -696,6 +790,9 @@ func TestAddEventAndFlushDataInvalidSequenceTokenNextNullException(t *testing.T)
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
@@ -714,12 +811,13 @@ func TestAddEventAndFlushDataInvalidSequenceTokenNextNullException(t *testing.T)
 	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -736,6 +834,9 @@ func TestAddEventAndDataResourceNotFoundExceptionWithNoLogGroup(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
@@ -750,12 +851,13 @@ func TestAddEventAndDataResourceNotFoundExceptionWithNoLogGroup(t *testing.T) {
 	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -771,6 +873,9 @@ func TestAddEventAndDataResourceNotFoundExceptionWithNoLogStream(t *testing.T) {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
@@ -786,12 +891,13 @@ func TestAddEventAndDataResourceNotFoundExceptionWithNoLogStream(t *testing.T) {
 	)
 
 	output := OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 
 	record := map[interface{}]interface{}{
@@ -893,6 +999,9 @@ func setupLimitTestOutput(t *testing.T, times int) OutputPlugin {
 	mockCloudWatch := mock_cloudwatch.NewMockLogsClient(ctrl)
 
 	gomock.InOrder(
+		mockCloudWatch.EXPECT().DescribeLogStreams(gomock.Any()).Do(func(input *cloudwatchlogs.DescribeLogStreamsInput) {
+			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
+		}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{}, nil),
 		mockCloudWatch.EXPECT().CreateLogStream(gomock.Any()).AnyTimes().Do(func(input *cloudwatchlogs.CreateLogStreamInput) {
 			assert.Equal(t, aws.StringValue(input.LogGroupName), testLogGroup, "Expected log group name to match")
 			assert.Equal(t, aws.StringValue(input.LogStreamName), testLogStreamPrefix+testTag, "Expected log stream name to match")
@@ -901,12 +1010,13 @@ func setupLimitTestOutput(t *testing.T, times int) OutputPlugin {
 	)
 
 	return OutputPlugin{
-		logGroupName:    testTemplate(testLogGroup),
-		logStreamPrefix: testLogStreamPrefix,
-		client:          mockCloudWatch,
-		timer:           setupTimeout(),
-		streams:         make(map[string]*logStream),
-		groups:          map[string]struct{}{testLogGroup: {}},
+		logGroupName:     testTemplate(testLogGroup),
+		logStreamPrefix:  testLogStreamPrefix,
+		client:           mockCloudWatch,
+		timer:            setupTimeout(),
+		streams:          make(map[string]*logStream),
+		groups:           map[string]struct{}{testLogGroup: {}},
+		autoCreateStream: true,
 	}
 }
 

--- a/fluent-bit-cloudwatch.go
+++ b/fluent-bit-cloudwatch.go
@@ -103,6 +103,9 @@ func getConfiguration(ctx unsafe.Pointer, pluginID int) cloudwatch.OutputPluginC
 	config.AutoCreateGroup = getBoolParam(ctx, "auto_create_group", false)
 	logrus.Infof("[cloudwatch %d] plugin parameter auto_create_group = '%v'", pluginID, config.AutoCreateGroup)
 
+	config.AutoCreateStream = getBoolParam(ctx, "auto_create_stream", true)
+	logrus.Infof("[cloudwatch %d] plugin parameter auto_create_stream = '%v'", pluginID, config.AutoCreateStream)
+
 	config.NewLogGroupTags = output.FLBPluginConfigKey(ctx, "new_log_group_tags")
 	logrus.Infof("[cloudwatch %d] plugin parameter new_log_group_tags = '%s'", pluginID, config.NewLogGroupTags)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change:
* Adds `auto_create_stream` config
* Changes behavior  to check if a stream exists first before attempting to create it.
* Fixes a bug where if a user manually deletes and recreates a stream then the plugin fails to make any progress 

Testing:
auto_create_stream false
- [x] Start fluent-bit with no log stream and stream not created
- [x] Create stream and logs start getting populated in the stream
- [x] Delete the stream and recreation isn't attempted
- [x] Create stream again and logs start getting populated in the stream

auto_create_stream true
- [x] Start fluent-bit with no log stream and stream is created and populated
- [x] Delete the stream and stream gets created and populated
- [x] Delete and create the stream and logs start getting populated in the stream
- [x] Start fluent-bit with log stream created and stream gets populated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Bug explained
The bug that was discovered causes the plugin to not make progress when a user deletes and creates a stream. This bug was existent before the changes but was just noticed more easily due to streams not being auto created.

When this delete + create happens the plugin will use an incorrect (old) `sequenceToken` and will get a `InvalidSequenceTokenException`. It attempts to recover from this by fetching the token from the error message by parsing the next token from the error message. With a new stream no sequence token is expected and the parsing from the error message fails. To fix we detect if it is a new stream and use `nil` nextSequenceToken insted.

Error for _normal_ sequence token error:
`An error occurred (InvalidSequenceTokenException) when calling the PutLogEvents operation: The given sequenceToken is invalid. The next expected sequenceToken is: 49621219915356076984497278709410931028996559626100016802`

Error for new stream sequence token error:
`An error occurred (InvalidSequenceTokenException) when calling the PutLogEvents operation: The given sequenceToken is invalid. The next expected sequenceToken is: null`