### PR TITLE
added support to build cloudwatch logs plugin for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
         go-version: 1.17
       id: go
 
+    - name: Install cross-compiler for Windows
+      run: sudo apt-get install -y gcc-multilib gcc-mingw-w64
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
@@ -26,4 +29,4 @@ jobs:
       run: go get -u golang.org/x/lint/golint
 
     - name: Build
-      run: make build test
+      run: make build windows-release test

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+# Build settings.
+GOARCH ?= amd64
+COMPILER ?= x86_64-w64-mingw32-gcc # Cross-compiler for Windows
+
 ROOT := $(shell pwd)
 
 all: build
@@ -18,6 +22,7 @@ all: build
 SCRIPT_PATH := $(ROOT)/scripts/:${PATH}
 SOURCES := $(shell find . -name '*.go')
 PLUGIN_BINARY := ./bin/cloudwatch.so
+PLUGIN_BINARY_WINDOWS := ./bin/cloudwatch.dll
 
 .PHONY: build
 build: $(PLUGIN_BINARY)
@@ -33,6 +38,12 @@ release:
 	mkdir -p ./bin
 	go build -buildmode c-shared -o $(PLUGIN_BINARY) ./
 	@echo "Built Amazon CloudWatch Logs Fluent Bit Plugin"
+
+.PHONY: windows-release
+windows-release:
+	mkdir -p ./bin
+	GOOS=windows GOARCH=$(GOARCH) CGO_ENABLED=1 CC=$(COMPILER) go build -buildmode c-shared -o $(PLUGIN_BINARY_WINDOWS) ./
+	@echo "Built Amazon CloudWatch Logs Fluent Bit Plugin for Windows"
 
 .PHONY: generate
 generate: $(SOURCES)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ Run `make` to build `./bin/cloudwatch.so`. Then use with Fluent Bit:
 -p "auto_create_group=true"
 ```
 
+For building Windows binaries, we need to install `mingw-64w` for cross-compilation. The same can be done using-
+```
+sudo apt-get install -y gcc-multilib gcc-mingw-w64
+```
+After this step, run `make windows-release`. Then use with Fluent Bit on Windows:
+```
+./fluent-bit.exe -e ./cloudwatch.dll -i dummy `
+-o cloudwatch `
+-p "region=us-west-2" `
+-p "log_group_name=fluent-bit-cloudwatch" `
+-p "log_stream_name=testing" `
+-p "auto_create_group=true"
+```
+
 ### Plugin Options
 
 * `region`: The AWS region.


### PR DESCRIPTION
## Summary
In order to build Windows artifacts, we have added a separate target for the same in Makefile. We are using a cross-compiler to build Windows artifacts.

Additionally, we have added the same to Github action on PR.

To ensure that customers building their own plugins can build Windows artifacts for different architectures and using different cross-compilers, the build settings are customisable.

Please note that we have not modified the existing targets or added Windows target to build target. This is because in order to build Windows artifacts, we need to install cross-compiler which by default is not available on most runtimes. Therefore, adding a separate Windows target ensures backward-compatibility.

## Testing
Installed the cross-compiler on an Ubuntu machine and then ran make windows-release
Then tested the built plugin with fluent-bit on Windows instance to ensure that the logs are received in Cloudwatch.

*Issue #, if available:*

## Description of changes:
added a target for Windows release in makefile




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
